### PR TITLE
Sync up postal code search return data to match name search return

### DIFF
--- a/backend/src/controllers/LandlordController.ts
+++ b/backend/src/controllers/LandlordController.ts
@@ -53,7 +53,24 @@ const searchLandlordWithName = async(name: string) => {
 
 const searchLandlordWithPostalCode = async(postalCode: string) => {
   try {
-    return getLandlordsFromPostalCode(postalCode);
+    const landlords = [];
+    const properties = await getLandlordsFromPostalCode(postalCode);
+    for (const property of properties) {
+      // Check if property landlord id is already contained in landlords array.
+      const foundIndex = landlords.findIndex(landlord => property.landlordId._id === landlord.landlord._id);
+      const { _id, postalCode, streetName, streetNumber } = property;
+      if (foundIndex < 0) {
+        const landlord = {
+          landlord: property.landlordId,
+          properties: [{ _id, postalCode, streetName, streetNumber, landlordId: property.landlordId._id }]
+        };
+        landlords.push(landlord);
+      } else {
+        landlords[foundIndex].properties.push({ _id, postalCode, streetName, streetNumber, landlordId: property.landlordId._id });
+      }
+    }
+
+    return landlords;
   } catch (error) {
     throw Error('Search by postal code database error.');
   }


### PR DESCRIPTION
This is to fix issue between discrepancies in the order in which data is returned in searching for landlord name vs searching for postal code. Postal code search now matches name search:
`http://localhost:8000/api/search?postalCode=T3K`
```
[
    {
        "landlord": {
            "_id": "65681a40eaa583cb22bcef09",
            "firstName": "Garrick",
            "lastName": "Henne",
            "organization": "dude imposter org",
            "createdAt": "2023-11-30T05:13:47.844Z",
            "__v": 0
        },
        "properties": [
            {
                "_id": "65681bb0eaa583cb22bcef0e",
                "postalCode": "T3K-0L4",
                "streetName": "E 13th",
                "streetNumber": 123,
                "landlordId": "65681a40eaa583cb22bcef09"
            },
            {
                "_id": "656823b07358f8d5ac4aba03",
                "postalCode": "T3K-0L4",
                "streetName": "E 13th",
                "streetNumber": 123,
                "landlordId": "65681a40eaa583cb22bcef09"
            }
        ]
    }
]
```